### PR TITLE
More fields on MessageData

### DIFF
--- a/discord/v1/model.proto
+++ b/discord/v1/model.proto
@@ -172,6 +172,10 @@ message MessageData {
   UserData author = 21;
   MemberData member = 22;
   SnowflakeValue webhook_id = 23;
+  repeated MessageStickerData stickers = 24;
+  MessageInteractionData interaction = 25;
+  ChannelData thread = 26;
+  repeated MessageComponentData components = 27;
 
   enum MessageType {
     UNKNOWN = 0;
@@ -245,6 +249,63 @@ message MessageData {
     fixed64 guild_id = 2 [jstype = JS_STRING];
     ChannelData.ChannelType type = 3;
     string name = 4;
+  }
+
+  message MessageStickerData {
+    fixed64 id = 1 [jstype = JS_STRING];
+    fixed64 pack_id = 2 [jstype = JS_STRING];
+    string name = 3;
+    string description = 4;
+    string tags = 5;
+    string asset = 6;
+    MessageStickerFormatType format_type = 7;
+
+    enum MessageStickerFormatType {
+      UNKNOWN = 0;
+      PNG = 1;
+      APNG = 2;
+      LOTTIE = 3;
+    }
+  }
+
+  message MessageInteractionData {
+    fixed64 id = 1 [jstype = JS_STRING];
+    MessageInteractionType type = 2;
+    string name = 3;
+    UserData user = 4;
+
+    enum MessageInteractionType {
+      UNKNOWN = 0;
+      PING = 1;
+      APPLICATION_COMMAND = 2;
+      MESSAGE_COMPONENT = 3;
+    }
+  }
+
+  message MessageComponentData {
+    enum MessageComponentType {
+      UNKNOWN = 0;
+      ACTION_ROW = 1;
+      BUTTON = 2;
+    }
+
+    enum MessageComponentButtonStyle {
+      UNKNOWN_BUTTON = 0;
+      PRIMARY = 1;
+      SECONDARY = 2;
+      SUCCESS = 3;
+      DANGER = 4;
+      LINK = 5;
+    }
+
+    MessageComponentType type = 1;
+    MessageComponentButtonStyle style = 2;
+    string label = 3;
+    MessageReactionEmojiData emoji = 4;
+    string custom_id = 5;
+    string url = 6;
+    bool disabled = 7;
+    repeated MessageComponentData components = 8;
   }
 
   message MessageEmbedData {

--- a/discord/v1/rest.proto
+++ b/discord/v1/rest.proto
@@ -538,7 +538,10 @@ message CreateMessageRequest {
   google.protobuf.BoolValue tts = 4;
   pylon.discord.v1.model.MessageData.MessageEmbedData embed = 5;
   AllowedMentions allowed_mentions = 6;
-  Attachment attachment = 7;
+  MessageReference message_reference = 7;
+  pylon.discord.v1.model.MessageData.MessageComponentData components = 8;
+
+  Attachment attachment = 99;
 
   message AllowedMentions {
     AllowedMentionTypes parse = 1;
@@ -550,6 +553,13 @@ message CreateMessageRequest {
       bool users = 2;
       bool everyone = 3;
     }
+  }
+
+  message MessageReference {
+    fixed64 message_id = 1 [jstype = JS_STRING];
+    fixed64 channel_id = 2 [jstype = JS_STRING];
+    fixed64 guild_id = 3 [jstype = JS_STRING];
+    bool fail_if_not_exists = 4;
   }
 
   message Attachment {


### PR DESCRIPTION
Appends the following fields to MessageData:
* stickers
* interactions
* thread
* components

Allows to specify the following new fields on MessageCreateRequest:
* message_reference
* components